### PR TITLE
Feature/implement full pid solution

### DIFF
--- a/src/ImageProcessor/communication/communication_manager.py
+++ b/src/ImageProcessor/communication/communication_manager.py
@@ -2,7 +2,8 @@ import configparser
 from typing import List, Tuple
 
 from communication.controller_notifier import ControllerNotifier
-from kinematics.kinematic_model import KinematicModel, KinematicValues
+from kinematics.kinematic_model import KinematicModel
+from kinematics.kinematic_values import KinematicValues
 from models.object import Object
 from models.sample import Sample
 from models.vehicle_enum import VehiclePart

--- a/src/ImageProcessor/config.ini
+++ b/src/ImageProcessor/config.ini
@@ -4,7 +4,7 @@ height = 480
 refresh_delay = 1
 input_slot = 0
 framerate = 24
-use_pi_camera = True
+use_pi_camera = False
 
 [object]
 MAX_NUM_OBJECTS = 25
@@ -23,6 +23,7 @@ draw_contours = False
 center_marker_radius = 4
 
 [communication]
+enabled = False
 sample_count = 15
 port = rfcomm0
 baudrate = 9600

--- a/src/ImageProcessor/config.ini
+++ b/src/ImageProcessor/config.ini
@@ -30,9 +30,13 @@ poll_interval_in_ms = 100
 
 [angle_controller]
 k_P = 1
+k_I = 0.001
+k_D = 1
 
 [distance_controller]
-k_p = 1
+k_P = 1
+k_I = 0.001
+k_D = 1
 margin = 10
 
 [other]

--- a/src/ImageProcessor/kinematics/kinematic_model.py
+++ b/src/ImageProcessor/kinematics/kinematic_model.py
@@ -1,46 +1,49 @@
 import configparser
-import struct
 from typing import Tuple
+from simple_pid import PID
 
 from math import atan2, pi, sqrt
 
-
-class KinematicValues:
-    def __init__(self, v: float, w: float):
-        self.v = v
-        self.w = w
-
-    def as_big_endian_bytes(self) -> bytearray:
-        """
-        First 4 bytes are v and last 4 are w
-        :return: byte array representing speed and angular speed
-        """
-        return bytearray(struct.pack('!f', self.v)) + bytearray(struct.pack('!f', self.w))
+from kinematics.kinematic_values import KinematicValues
 
 
 class KinematicModel:
     def __init__(self, config: configparser.ConfigParser):
-        self.__angle_kp = config.getfloat('angle_controller', 'k_P')
         self.__distance_margin = config.getfloat('distance_controller', 'margin')
-        self.__distance_kp = config.getfloat('distance_controller', 'k_P')
         self.__current_goal: Tuple[int, int] = None
+
+        self.__v_pid = PID(config.getfloat('angle_controller', 'k_P'), config.getfloat('angle_controller', 'k_I'),
+                           config.getfloat('angle_controller', 'k_D'))
+        self.__w_pid = PID(config.getfloat('angle_controller', 'k_P'), config.getfloat('angle_controller', 'k_I'),
+                           config.getfloat('angle_controller', 'k_D'))
 
     def get_kinematic_values(self, trunk: Tuple[int, int], hood: Tuple[int, int],
                              goal: Tuple[int, int]) -> KinematicValues:
 
+        if goal != self.__current_goal:
+            self.__v_pid.reset()
+            self.__w_pid.reset()
+
         robot = ((trunk[0] + hood[0]) / 2, (trunk[1] + hood[1]) / 2)
 
+        delta_phi = self.get_angle_to_goal(goal, hood, robot, trunk)
+        dist_to_goal = self.get_distance_to_goal(robot, goal)
+
+        w = self.__w_pid(delta_phi)
+        v = self.__v_pid(dist_to_goal)
+
+        return KinematicValues(v, w)
+
+    @staticmethod
+    def get_angle_to_goal(goal, hood, robot, trunk):
         delta_phi = atan2(goal[1] - robot[1], goal[0] - robot[0])
 
         # Account for orientation
         if hood[1] < trunk[1]:
             delta_phi += pi + delta_phi
+        return delta_phi
 
+    def get_distance_to_goal(self, robot: Tuple[float, float], goal: Tuple[float, float]) -> float:
         dist_to_goal = sqrt((robot[0] - goal[0]) ** 2 + (robot[1] - goal[1]) ** 2)
-        if dist_to_goal < self.__distance_margin:
-            dist_to_goal = 0
 
-        w = self.__angle_kp * delta_phi
-        v = self.__distance_kp * dist_to_goal if dist_to_goal >= self.__distance_margin else 0
-
-        return KinematicValues(v, w)
+        return 0 if dist_to_goal < self.__distance_margin else dist_to_goal

--- a/src/ImageProcessor/kinematics/kinematic_model.py
+++ b/src/ImageProcessor/kinematics/kinematic_model.py
@@ -23,6 +23,7 @@ class KinematicModel:
         if goal != self.__current_goal:
             self.__v_pid.reset()
             self.__w_pid.reset()
+            self.__current_goal = goal
 
         robot = ((trunk[0] + hood[0]) / 2, (trunk[1] + hood[1]) / 2)
 

--- a/src/ImageProcessor/kinematics/kinematic_values.py
+++ b/src/ImageProcessor/kinematics/kinematic_values.py
@@ -1,0 +1,14 @@
+import struct
+
+
+class KinematicValues:
+    def __init__(self, v: float, w: float):
+        self.v = v
+        self.w = w
+
+    def as_big_endian_bytes(self) -> bytearray:
+        """
+        First 4 bytes are v and last 4 are w
+        :return: byte array representing speed and angular speed
+        """
+        return bytearray(struct.pack('!f', self.v)) + bytearray(struct.pack('!f', self.w))

--- a/src/ImageProcessor/kinematics/kinematic_values.py
+++ b/src/ImageProcessor/kinematics/kinematic_values.py
@@ -12,3 +12,6 @@ class KinematicValues:
         :return: byte array representing speed and angular speed
         """
         return bytearray(struct.pack('!f', self.v)) + bytearray(struct.pack('!f', self.w))
+
+    def __repr__(self):
+        return f'v:{self.v}, w:{self.w}'

--- a/src/ImageProcessor/requirements.txt
+++ b/src/ImageProcessor/requirements.txt
@@ -3,3 +3,4 @@ numpy==1.19.4; platform_system == "Linux"
 opencv-python==4.4.0.46
 pyserial==3.5
 picamera==1.13; platform_system == "Linux"
+simple-pid==0.2.4


### PR DESCRIPTION
Implemented full PID solution for both linear and angular velocity (no matter if we end up using linear speed at all).

The target value for both PIDs is 0 and the value that is provided to the PID is a corresponding error. 
By utilizing this approach it's not necessary to re-instantiate PID every time the goal changes because the optimization goal is always the same - to have the error be 0.

Added toggle switch for communication so it's not necessary to fake the `rfcomm` port locally when testing.